### PR TITLE
[feat] 예약 내역 조회[단건/전체]

### DIFF
--- a/src/main/java/com/sparta/sportify/controller/ReservationController.java
+++ b/src/main/java/com/sparta/sportify/controller/ReservationController.java
@@ -1,18 +1,20 @@
 package com.sparta.sportify.controller;
 
 import com.sparta.sportify.dto.reservation.request.ReservationRequestDto;
+import com.sparta.sportify.dto.reservation.response.ReservationFindResponseDto;
 import com.sparta.sportify.dto.reservation.response.ReservationResponseDto;
 import com.sparta.sportify.security.UserDetailsImpl;
 import com.sparta.sportify.service.ReservationService;
 import com.sparta.sportify.util.api.ApiResult;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
@@ -26,19 +28,19 @@ public class ReservationController {
             @RequestBody ReservationRequestDto requestDto,
             @AuthenticationPrincipal UserDetailsImpl authUser
     ) {
-        if(requestDto.getTeamMemberIdList().isEmpty()){
+        if (requestDto.getTeamMemberIdList().isEmpty()) {
             return new ResponseEntity<>(
                     ApiResult.success(
                             "개인예약 성공",
-                            reservationService.reservationPersonal(requestDto,authUser)
+                            reservationService.reservationPersonal(requestDto, authUser)
                     ),
                     HttpStatus.CREATED
             );
-        }else{
+        } else {
             return new ResponseEntity<>(
                     ApiResult.success(
                             "개인예약 성공",
-                            reservationService.reservationGroup(requestDto,authUser)
+                            reservationService.reservationGroup(requestDto, authUser)
                     ),
                     HttpStatus.CREATED
             );
@@ -46,5 +48,34 @@ public class ReservationController {
 
     }
 
+//    /reservations?page=0&size=10
+    @GetMapping("/reservations")
+    public ResponseEntity<ApiResult<Slice<ReservationFindResponseDto>>> findAllReservations(
+            @AuthenticationPrincipal UserDetailsImpl authUser,
+            @PageableDefault(size = 10, sort = "id", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+
+        return new ResponseEntity<>(
+                ApiResult.success(
+                        "개인예약 성공",
+                        reservationService.findReservationsForInfiniteScroll(authUser,pageable)
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    @GetMapping("/reservations/{reservationId}")
+    public ResponseEntity<ApiResult<ReservationFindResponseDto>> findReservations(
+            @PathVariable Long reservationId,
+            @AuthenticationPrincipal UserDetailsImpl authUser
+    ) {
+        return new ResponseEntity<>(
+                ApiResult.success(
+                        "개인예약 성공",
+                        reservationService.findReservation(reservationId, authUser)
+                ),
+                HttpStatus.OK
+        );
+    }
 
 }

--- a/src/main/java/com/sparta/sportify/dto/reservation/response/ReservationFindResponseDto.java
+++ b/src/main/java/com/sparta/sportify/dto/reservation/response/ReservationFindResponseDto.java
@@ -1,0 +1,33 @@
+package com.sparta.sportify.dto.reservation.response;
+
+
+import com.sparta.sportify.dto.stadium.response.StadiumResponseDto;
+import com.sparta.sportify.entity.Reservation;
+import com.sparta.sportify.entity.Stadium;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class ReservationFindResponseDto {
+    Long userId;
+    Long reservationId;
+    StadiumResponseDto stadium;
+    LocalDate reservationDate;
+    Integer totalAmount;
+
+    public ReservationFindResponseDto(Reservation reservation){
+        this.userId = reservation.getUser().getId();
+        this.reservationId = reservation.getId();
+        this.stadium = new StadiumResponseDto(reservation.getMatch().getStadiumTime().getStadium());
+        this.reservationDate = reservation.getReservationDate();
+        this.totalAmount = reservation.getTotalAmount();
+    }
+
+}

--- a/src/main/java/com/sparta/sportify/repository/ReservationRepository.java
+++ b/src/main/java/com/sparta/sportify/repository/ReservationRepository.java
@@ -2,6 +2,8 @@ package com.sparta.sportify.repository;
 
 import com.sparta.sportify.entity.Reservation;
 import com.sparta.sportify.entity.User;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -20,4 +22,7 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
             @Param("time") Integer time,
             @Param("reservationDate") LocalDate reservationDate
     );
+
+
+    Slice<Reservation> findByUserIdOrderByIdDesc(Long userId, Pageable pageable);
 }


### PR DESCRIPTION
## 단건 조회 시나리오
 - 예약 내역 단건 조회 성공
   - 예약 ID를 입력받아 해당 예약 내역을 정상적으로 반환.
   - 조건:
     - 요청한 예약 ID가 존재해야 함.
     - 예약 정보에 사용자 본인의 정보만 포함.
   - 예상 결과:
     -예약 정보 반환 (예약일, 시간, 경기 정보, 사용자 정보, 팀 컬러 등).


## 전체 조회 시나리오
 - 사용자의 예약 내역 전체 조회 성공
   - 현재 사용자의 모든 예약 정보를 반환.
   - 조건:
     - 요청자가 본인의 예약 내역을 요청.
   - 예상 결과:
     - 예약 목록 반환 (예약일, 시간, 경기 정보, 사용자 정보, 팀 컬러, 상태 등).
     - 예약 내역이 없을 경우 빈 목록 반환.