### PR TITLE
[FEAT] 경기 결과 조회

### DIFF
--- a/src/main/java/com/sparta/sportify/controller/MatchController.java
+++ b/src/main/java/com/sparta/sportify/controller/MatchController.java
@@ -2,6 +2,8 @@ package com.sparta.sportify.controller;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,5 +28,11 @@ public class MatchController {
 		@Validated @RequestBody MatchResultRequestDto requestDto) {
 		MatchResultResponseDto responseDto = matchService.createMatchResult(requestDto);
 		return ResponseEntity.ok(ApiResult.success("경기 결과 기록",responseDto));
+	}
+
+	@GetMapping("/result/{matchId}")
+	public ResponseEntity<ApiResult<MatchResultResponseDto>> getMatchResult(@PathVariable Long matchId) {
+		MatchResultResponseDto responseDto = matchService.getMatchResult(matchId);
+		return ResponseEntity.ok(ApiResult.success("경기 결과 조회", responseDto));
 	}
 }

--- a/src/main/java/com/sparta/sportify/controller/MatchController.java
+++ b/src/main/java/com/sparta/sportify/controller/MatchController.java
@@ -25,6 +25,6 @@ public class MatchController {
 	public ResponseEntity<ApiResult<MatchResultResponseDto>> createMatchResult(
 		@Validated @RequestBody MatchResultRequestDto requestDto) {
 		MatchResultResponseDto responseDto = matchService.createMatchResult(requestDto);
-		return ResponseEntity.ok(ApiResult.success(responseDto));
+		return ResponseEntity.ok(ApiResult.success("경기 결과 기록",responseDto));
 	}
 }

--- a/src/main/java/com/sparta/sportify/entity/StadiumStatus.java
+++ b/src/main/java/com/sparta/sportify/entity/StadiumStatus.java
@@ -4,7 +4,7 @@ import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
 public enum StadiumStatus {
-	PENDING("대기"),APPROVED("승인"),REJECTED("거절");
+	PENDING("대기"),APPROVED("승인"),REJECTED("거절"),AVAILABLE("누락");
 
 	private final String value;
 }

--- a/src/main/java/com/sparta/sportify/entity/StadiumStatus.java
+++ b/src/main/java/com/sparta/sportify/entity/StadiumStatus.java
@@ -4,7 +4,7 @@ import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
 public enum StadiumStatus {
-	PENDING("대기"),APPROVED("승인"),REJECTED("거절"),AVAILABLE("누락");
+	PENDING("대기"),APPROVED("승인"),REJECTED("거절");
 
 	private final String value;
 }

--- a/src/main/java/com/sparta/sportify/repository/MatchResultRepository.java
+++ b/src/main/java/com/sparta/sportify/repository/MatchResultRepository.java
@@ -1,7 +1,10 @@
 package com.sparta.sportify.repository;
 
+import java.util.Optional;
+
 import com.sparta.sportify.entity.MatchResult;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MatchResultRepository extends JpaRepository<MatchResult, Long> {
+	Optional<MatchResult> findByMatchId(Long matchId);
 }

--- a/src/main/java/com/sparta/sportify/service/MatchService.java
+++ b/src/main/java/com/sparta/sportify/service/MatchService.java
@@ -44,4 +44,18 @@ public class MatchService {
 			savedResult.getMatchDate()
 		);
 	}
+
+	@Transactional(readOnly = true)
+	public MatchResultResponseDto getMatchResult(Long matchId) {
+		MatchResult matchResult = matchResultRepository.findByMatchId(matchId)
+			.orElseThrow(() -> new EntityNotFoundException("경기 결과를 찾을 수 없습니다."));
+
+		return new MatchResultResponseDto(
+			matchResult.getId(),
+			matchResult.getTeamAScore(),
+			matchResult.getTeamBScore(),
+			matchResult.getMatchStatus(),
+			matchResult.getMatchDate()
+		);
+	}
 }


### PR DESCRIPTION
요구사항
모든 사용자는 경기 결과를 조회할 수 있다.

예외사항
요청한 경기 ID가 유효해야 한다.

GET http://localhost:8080/api/matches/result/{matchId}

**ResponseBody**
```json
{
    "success": true,
    "message": "경기 결과 조회",
    "data": {
        "id": 1,
        "teamAScore": 4,
        "teamBScore": 2,
        "matchStatus": "CLOSED",
        "matchDate": "2024-12-09"
    },
    "apiError": null,
    "timestamp": "2024-12-09T19:28:06.359"
}
```