### PR TITLE
[FEAT] 경기 결과 입력시 유저와 팀에 점수 부여

### DIFF
--- a/src/main/java/com/sparta/sportify/repository/ReservationRepository.java
+++ b/src/main/java/com/sparta/sportify/repository/ReservationRepository.java
@@ -1,5 +1,6 @@
 package com.sparta.sportify.repository;
 
+import com.sparta.sportify.entity.Match;
 import com.sparta.sportify.entity.Reservation;
 import com.sparta.sportify.entity.ReservationStatus;
 import com.sparta.sportify.entity.User;
@@ -31,4 +32,6 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
         "LEFT JOIN Reservation r ON r.match.id = m.id AND r.status = :status " +
         "WHERE m.id = :matchId")
     Integer findTotalAmountByMatchId(@Param("matchId") Long matchId, ReservationStatus status);
+
+    List<Reservation> findAllByMatch(Match match);
 }

--- a/src/main/java/com/sparta/sportify/service/MatchService.java
+++ b/src/main/java/com/sparta/sportify/service/MatchService.java
@@ -69,6 +69,8 @@ public class MatchService {
 				pointChange = (reservation.getTeamColor() == TeamColor.A) ? 10 : -10;
 			} else if (requestDto.getTeamBScore() > requestDto.getTeamAScore()) {
 				pointChange = (reservation.getTeamColor() == TeamColor.B) ? 10 : -10;
+			} else {
+				pointChange = 5;
 			}
 
 			user.setLevelPoints(user.getLevelPoints() + pointChange);
@@ -85,6 +87,8 @@ public class MatchService {
 				teampointChange = (reservation.getTeamColor() == TeamColor.A) ? 10: -10;
 			} else if (requestDto.getTeamBScore() > requestDto.getTeamAScore()) {
 				teampointChange= (reservation.getTeamColor() == TeamColor.B) ? 10: -10;
+			} else {
+				teampointChange = 5;
 			}
 
 			team.setTeamPoints(team.getTeamPoints() + teampointChange);

--- a/src/main/java/com/sparta/sportify/service/MatchService.java
+++ b/src/main/java/com/sparta/sportify/service/MatchService.java
@@ -21,6 +21,7 @@ import com.sparta.sportify.entity.Match;
 import com.sparta.sportify.entity.MatchResult;
 import com.sparta.sportify.entity.Reservation;
 import com.sparta.sportify.entity.StadiumTime;
+import com.sparta.sportify.entity.Team;
 import com.sparta.sportify.entity.TeamColor;
 import com.sparta.sportify.entity.User;
 import com.sparta.sportify.repository.MatchRepository;
@@ -72,6 +73,22 @@ public class MatchService {
 
 			user.setLevelPoints(user.getLevelPoints() + pointChange);
 			userRepository.save(user);
+		});
+
+		// 경기 결과에 따른 팀 점수 부여
+		List<Reservation> reservationsTeam = reservationRepository.findAllByMatch(match);
+		reservationsTeam.forEach(reservation -> {
+			Team team = reservation.getTeam();
+			int teampointChange = 0;
+
+			if(requestDto.getTeamAScore() > requestDto.getTeamBScore()) {
+				teampointChange = (reservation.getTeamColor() == TeamColor.A) ? 10: -10;
+			} else if (requestDto.getTeamBScore() > requestDto.getTeamAScore()) {
+				teampointChange= (reservation.getTeamColor() == TeamColor.B) ? 10: -10;
+			}
+
+			team.setTeamPoints(team.getTeamPoints() + teampointChange);
+			teamRepository.save(team);
 		});
 
 

--- a/src/main/java/com/sparta/sportify/service/MatchService.java
+++ b/src/main/java/com/sparta/sportify/service/MatchService.java
@@ -6,8 +6,14 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -79,18 +85,38 @@ public class MatchService {
 
 		// 경기 결과에 따른 팀 점수 부여
 		List<Reservation> reservationsTeam = reservationRepository.findAllByMatch(match);
+		// 중복 없는 Team-Reservation 매핑을 Set으로 생성
+		Set<Map<Team, Reservation>> uniqueTeamReservations = new HashSet<>();
 		reservationsTeam.forEach(reservation -> {
 			Team team = reservation.getTeam();
+			if (team != null) {
+				Map<Team, Reservation> map = new HashMap<>();
+				map.put(team, reservation);
+				uniqueTeamReservations.add(map);
+			}
+		});
+		// Set 처리
+		Set<Team> uniqueTeams = reservationsTeam.stream()
+			.map(Reservation::getTeam)
+			.filter(Objects::nonNull)
+			.collect(Collectors.toSet());
+		uniqueTeams.forEach(team -> {
+			// 관련된 Reservation 중 하나를 가져오기 (팀 기반)
+			Reservation relatedReservation = reservationsTeam.stream()
+				.filter(reservation -> team.equals(reservation.getTeam()))
+				.findFirst() // 첫 번째 매칭된 Reservation 가져오기
+				.orElseThrow(() -> new IllegalStateException("Reservation not found for team"));
+			// Reservation의 TeamColor로 점수 계산
+			TeamColor teamColor = relatedReservation.getTeamColor();
 			int teampointChange = 0;
-
-			if(requestDto.getTeamAScore() > requestDto.getTeamBScore()) {
-				teampointChange = (reservation.getTeamColor() == TeamColor.A) ? 10: -10;
+			if (requestDto.getTeamAScore() > requestDto.getTeamBScore()) {
+				teampointChange = (teamColor == TeamColor.A) ? 10 : -10;
 			} else if (requestDto.getTeamBScore() > requestDto.getTeamAScore()) {
-				teampointChange= (reservation.getTeamColor() == TeamColor.B) ? 10: -10;
+				teampointChange = (teamColor == TeamColor.B) ? 10 : -10;
 			} else {
 				teampointChange = 5;
 			}
-
+			// 점수 업데이트
 			team.setTeamPoints(team.getTeamPoints() + teampointChange);
 			teamRepository.save(team);
 		});


### PR DESCRIPTION
매치 결과에 점수를 입력하면 유저, 팀에 각각 점수 부여
승리 + 10점
패배 - 10점
무승부 + 5점

RequestBody
```json
{
  "teamAScore": 4,
  "teamBScore": 2,
  "matchStatus": "CLOSED",
  "matchId": 1
}