### PR TITLE
[Feat] 쿠폰,예약 동시성 처리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,6 +83,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 
+
+    implementation 'org.redisson:redisson-spring-boot-starter:3.24.3'
+
 }
 
 dependencyManagement {

--- a/src/main/java/com/sparta/sportify/annotation/RedissonLock.java
+++ b/src/main/java/com/sparta/sportify/annotation/RedissonLock.java
@@ -1,0 +1,19 @@
+package com.sparta.sportify.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RedissonLock {
+    String key();
+
+    TimeUnit timeUnit() default TimeUnit.SECONDS;
+
+    long waitTime() default 5L;
+
+    long leaseTime() default 3L;
+}

--- a/src/main/java/com/sparta/sportify/aspect/AopForTransaction.java
+++ b/src/main/java/com/sparta/sportify/aspect/AopForTransaction.java
@@ -1,0 +1,16 @@
+package com.sparta.sportify.aspect;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Component
+public class AopForTransaction {
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Object proceed(final ProceedingJoinPoint joinPoint) throws Throwable {
+        return joinPoint.proceed();
+    }
+}

--- a/src/main/java/com/sparta/sportify/aspect/CustomSpringELParser.java
+++ b/src/main/java/com/sparta/sportify/aspect/CustomSpringELParser.java
@@ -1,0 +1,21 @@
+package com.sparta.sportify.aspect;
+
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+public class CustomSpringELParser {
+    private CustomSpringELParser() {
+    }
+
+    public static Object getDynamicValue(String[] parameterNames, Object[] args, String key) {
+        ExpressionParser parser = new SpelExpressionParser();
+        StandardEvaluationContext context = new StandardEvaluationContext();
+
+        for (int i = 0; i < parameterNames.length; i++) {
+            context.setVariable(parameterNames[i], args[i]);
+        }
+
+        return parser.parseExpression(key).getValue(context, Object.class);
+    }
+}

--- a/src/main/java/com/sparta/sportify/aspect/RedissonLockAop.java
+++ b/src/main/java/com/sparta/sportify/aspect/RedissonLockAop.java
@@ -1,0 +1,53 @@
+package com.sparta.sportify.aspect;
+
+import com.sparta.sportify.annotation.RedissonLock;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RedissonLockAop {
+    private static final String REDISSON_LOCK_PREFIX = "LOCK:";
+
+    private final RedissonClient redissonClient;
+    private final AopForTransaction aopForTransaction;
+
+    @Around("@annotation(com.sparta.sportify.annotation.RedissonLock)")
+    public Object lock(final ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        RedissonLock distributedLock = method.getAnnotation(RedissonLock.class);
+
+        String key = REDISSON_LOCK_PREFIX + CustomSpringELParser.getDynamicValue(signature.getParameterNames(), joinPoint.getArgs(), distributedLock.key());
+        RLock rLock = redissonClient.getLock(key);  // (1)
+
+        try {
+            boolean available = rLock.tryLock(distributedLock.waitTime(), distributedLock.leaseTime(), distributedLock.timeUnit());
+            if (!available) {
+                return false;
+            }
+
+            return aopForTransaction.proceed(joinPoint);
+        } catch (InterruptedException e) {
+            throw new InterruptedException();
+        } finally {
+            try {
+                rLock.unlock();   // (4)
+            } catch (IllegalMonitorStateException e) {
+                log.info("Redisson Lock Already UnLock - serviceName: {}, key: {}",
+                        method.getName(), key);
+            }
+        }
+    }
+}

--- a/src/main/java/com/sparta/sportify/config/RedissonConfig.java
+++ b/src/main/java/com/sparta/sportify/config/RedissonConfig.java
@@ -1,0 +1,28 @@
+package com.sparta.sportify.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedissonConfig {
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    private static final String REDISSON_HOST_PREFIX = "redis://";
+
+    @Bean
+    public RedissonClient redissonClient() {
+        RedissonClient redisson = null;
+        Config config = new Config();
+        config.useSingleServer().setAddress(REDISSON_HOST_PREFIX + redisHost + ":" + redisPort);
+        redisson = Redisson.create(config);
+        return redisson;
+    }
+}

--- a/src/main/java/com/sparta/sportify/entity/Match.java
+++ b/src/main/java/com/sparta/sportify/entity/Match.java
@@ -41,7 +41,7 @@ public class Match {
     private StadiumTime stadiumTime;
 
     public void discountATeamCount(int count) {
-        this.bTeamCount -= count;
+        this.aTeamCount -= count;
     }
     public void discountBTeamCount(int count) {
         this.bTeamCount -= count;

--- a/src/main/java/com/sparta/sportify/entity/Match.java
+++ b/src/main/java/com/sparta/sportify/entity/Match.java
@@ -42,9 +42,15 @@ public class Match {
 
     public void discountATeamCount(int count) {
         this.aTeamCount -= count;
+        if(this.aTeamCount < 0) {
+            throw new RuntimeException("인원수가 초과되었습니다.");
+        }
     }
     public void discountBTeamCount(int count) {
         this.bTeamCount -= count;
+        if(this.bTeamCount < 0) {
+            throw new RuntimeException("인원수가 초과되었습니다.");
+        }
     }
 
     public void addATeamCount(int count) {

--- a/src/main/java/com/sparta/sportify/service/CouponService.java
+++ b/src/main/java/com/sparta/sportify/service/CouponService.java
@@ -1,5 +1,6 @@
 package com.sparta.sportify.service;
 
+import com.sparta.sportify.annotation.RedissonLock;
 import com.sparta.sportify.dto.cash.response.CashLogCouponUseResponse;
 import com.sparta.sportify.dto.coupon.request.CouponCreateRequestDto;
 import com.sparta.sportify.dto.coupon.response.CouponCreateResponseDto;
@@ -63,7 +64,7 @@ public class CouponService {
         return new SliceImpl<>(couponHistory, pageable, cashLogSlice.hasNext());
     }
 
-    @Transactional
+    @RedissonLock(key="'coupon-'.concat(#code)")
     public CashLogCouponUseResponse useCoupon(String code, UserDetailsImpl authUser) {
         Coupon coupon = couponRepository.findByCode(code).orElseThrow(()->{
             throw new RuntimeException("존재하지않는 쿠폰입니다.");

--- a/src/main/java/com/sparta/sportify/service/CouponService.java
+++ b/src/main/java/com/sparta/sportify/service/CouponService.java
@@ -8,6 +8,7 @@ import com.sparta.sportify.dto.coupon.response.CouponUserHistoryResponseDto;
 import com.sparta.sportify.entity.*;
 import com.sparta.sportify.repository.CashLogRepository;
 import com.sparta.sportify.repository.CouponRepository;
+import com.sparta.sportify.repository.UserRepository;
 import com.sparta.sportify.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -25,6 +26,7 @@ import java.util.stream.Collectors;
 public class CouponService {
     public final CouponRepository couponRepository;
     public final CashLogRepository cashLogRepository;
+    private final UserRepository userRepository;
 
     @Transactional
     public CouponCreateResponseDto createCoupon(CouponCreateRequestDto couponCreateRequestDto) {
@@ -85,6 +87,9 @@ public class CouponService {
                 .type(CashType.COUPON)
                 .price(coupon.getPrice())
                 .build());
+
+        authUser.getUser().setCash(authUser.getUser().getCash()+coupon.getPrice());
+        userRepository.save(authUser.getUser());
 
         return CashLogCouponUseResponse.builder()
                 .couponCode(cashLog.getCoupon().getCode())

--- a/src/main/java/com/sparta/sportify/service/ReservationService.java
+++ b/src/main/java/com/sparta/sportify/service/ReservationService.java
@@ -1,5 +1,6 @@
 package com.sparta.sportify.service;
 
+import com.sparta.sportify.annotation.RedissonLock;
 import com.sparta.sportify.dto.reservation.request.ReservationRequestDto;
 import com.sparta.sportify.dto.reservation.response.ReservationFindResponseDto;
 import com.sparta.sportify.dto.reservation.response.ReservationResponseDto;
@@ -27,9 +28,8 @@ public class ReservationService {
     private final CashLogRepository cashLogRepository;
 
 
-    @Transactional
+    @RedissonLock(key="'reservation-'.concat(#requestDto.getReservationDate().toString()).concat('/').concat(#requestDto.getStadiumTimeId().toString())")
     public ReservationResponseDto reservationPersonal(ReservationRequestDto requestDto, UserDetailsImpl authUser) {
-
         StadiumTime stadiumTime = stadiumTimeRepository.findById(requestDto.getStadiumTimeId()).orElseThrow(
                 () -> new RuntimeException("구장이 운영중이 아닙니다.")
         );
@@ -112,7 +112,7 @@ public class ReservationService {
         return new ReservationResponseDto(reservation.getId());
     }
 
-    @Transactional
+    @RedissonLock(key="'reservation-'.concat(#reqeustDto.getReservationDate()).concat('/').concat(#requestDto.getStadiumTimeId())")
     public ReservationResponseDto reservationGroup(ReservationRequestDto requestDto, UserDetailsImpl authUser) {
 
         StadiumTime stadiumTime = stadiumTimeRepository.findById(requestDto.getStadiumTimeId()).orElseThrow(

--- a/src/test/java/com/sparta/sportify/service/coupon/CouponServiceConcurrencyTest.java
+++ b/src/test/java/com/sparta/sportify/service/coupon/CouponServiceConcurrencyTest.java
@@ -1,0 +1,91 @@
+package com.sparta.sportify.service.coupon;
+
+import com.sparta.sportify.entity.*;
+import com.sparta.sportify.repository.CouponRepository;
+import com.sparta.sportify.repository.UserRepository;
+import com.sparta.sportify.security.UserDetailsImpl;
+import com.sparta.sportify.service.CouponService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+@Transactional
+@SpringBootTest
+public class CouponServiceConcurrencyTest {
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private CouponRepository couponRepository;
+
+    @Autowired
+    private CouponService couponService;
+
+    List<User> listUser = new ArrayList<>();
+
+    void dataSetUp() {
+        for (int i = 0; i < 30; i++) {
+            listUser.add(userRepository.save(User.builder().
+                    email("testerspring" + i + "@test.com")
+                    .age(20L)
+                    .cash(30000L)
+                    .name("이름" + i)
+                    .gender("남성")
+                    .levelPoints(1000L)
+                    .password("test1234!")
+                    .role(UserRole.USER)
+                    .region("지역지역")
+                    .build()
+            ));
+        }
+
+        couponRepository.save(Coupon.builder()
+                .price(2000L)
+                .count(20L)
+                .status(CouponStatus.AVAILABLE)
+                .code("NEWYEAR2025")
+                .expireDate(LocalDate.of(2025, 01, 01))
+                .name("새해기념")
+                .build());
+
+    }
+
+    @Test
+    void couponUseTest() throws InterruptedException {
+        final int numberOfThreads = 30;
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+
+        CyclicBarrier barrier = new CyclicBarrier(numberOfThreads);
+        executorService.submit(() -> {
+            dataSetUp();
+        });
+
+        for (int i = 0; i < numberOfThreads; i++) {
+            final int index = i;
+            executorService.submit(() -> {
+                try {
+                    barrier.await();
+                    UserDetailsImpl authUser = new UserDetailsImpl(listUser.get(index).getEmail(),UserRole.USER,listUser.get(index));
+                    couponService.useCoupon("NEWYEAR2025",authUser);
+
+
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            });
+        }
+
+        executorService.shutdown();
+        executorService.awaitTermination(1, TimeUnit.MINUTES);
+
+    }
+}

--- a/src/test/java/com/sparta/sportify/service/reservation/ReservationConcurrencyTest.java
+++ b/src/test/java/com/sparta/sportify/service/reservation/ReservationConcurrencyTest.java
@@ -1,0 +1,144 @@
+package com.sparta.sportify.service.reservation;
+
+import com.sparta.sportify.dto.reservation.request.ReservationRequestDto;
+import com.sparta.sportify.entity.*;
+import com.sparta.sportify.repository.*;
+import com.sparta.sportify.security.UserDetailsImpl;
+import com.sparta.sportify.service.ReservationService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+
+@Transactional
+@SpringBootTest
+public class ReservationConcurrencyTest {
+
+    @Autowired
+    private TeamRepository teamRepository;
+
+    @Autowired
+    private StadiumTimeRepository stadiumTimeRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ReservationService reservationService;
+
+    @Autowired
+    private StadiumRepository stadiumRepository;
+
+    List<User> listUser = new ArrayList<>();
+    Stadium stadium;
+    StadiumTime stadiumTime;
+    List<ReservationRequestDto> listRequestDto = new ArrayList<>();
+    Team team;
+    List<TeamMember> teamMembers = new ArrayList<>();
+
+    @Autowired
+    private TeamMemberRepository teamMemberRepository;
+
+    void dataSetUp() {
+        for (int i = 0; i < 30; i++) {
+            listUser.add(userRepository.save(User.builder().
+                    email("testerspring" + i + "@test.com")
+                    .age(20L)
+                    .cash(30000L)
+                    .name("이름" + i)
+                    .gender("남성")
+                    .levelPoints(1000L)
+                    .password("test1234!")
+                    .role(UserRole.USER)
+                    .region("지역지역")
+                    .build()
+            ));
+        }
+
+        stadium = stadiumRepository.save(Stadium.builder()
+                .price(2000L)
+                .aTeamCount(6)
+                .bTeamCount(6)
+                .status(StadiumStatus.APPROVED)
+                .user(listUser.get(0))
+                .build()
+        );
+
+        stadiumTime = stadiumTimeRepository.saveAndFlush(StadiumTime.builder()
+                .stadium(stadium)
+                .cron("0 0 10-12,12-14 ? * MON,TUE,WED,THU,FRI,SAT,SUN")
+                .build()
+        );
+//        유저1-10까지 팀이라 가정
+        Team team = teamRepository.save(Team.builder()
+                .region("경기")
+                .activityTime("16-20")
+                .teamName("테스트팀")
+                .description("설명")
+                .skillLevel("고수")
+                .sportType("축구")
+                .teamPoints(2000)
+                .build());
+
+        for (int i = 0; i < 10; i++) {
+            teamMembers.add(teamMemberRepository.save(TeamMember.builder()
+                    .user(listUser.get(0))
+                    .team(team)
+                    .teamMemberRole(i==0 ? TeamMemberRole.TEAM_OWNER : TeamMemberRole.USER)
+                    .status(TeamMember.Status.APPROVED)
+                    .build()));
+        }
+
+        for (int i = 0; i < 30; i++) {
+            listRequestDto.add(new ReservationRequestDto());
+            listRequestDto.get(i).setStadiumTimeId(stadiumTime.getId());
+            listRequestDto.get(i).setReservationDate(LocalDate.of(2024, 12, 3));
+            listRequestDto.get(i).setTime(10);
+            listRequestDto.get(i).setTeamColor(i < 15 ? TeamColor.A :TeamColor.B);
+        }
+
+
+    }
+
+        @Test
+        void reservationConcurrencyPersonal() throws InterruptedException {
+        final int numberOfThreads = 30;
+
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+
+        CyclicBarrier barrier = new CyclicBarrier(numberOfThreads);
+
+        executorService.submit(() -> {
+            dataSetUp();
+        });
+
+        for (int i = 0; i < numberOfThreads; i++) {
+            final int index = i;
+            executorService.submit(() -> {
+                try {
+                    barrier.await();
+                    UserDetailsImpl authUser = new UserDetailsImpl(listUser.get(index).getEmail(),UserRole.USER,listUser.get(index));
+                    reservationService.reservationPersonal(listRequestDto.get(index),authUser);
+
+
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            });
+        }
+
+        executorService.shutdown();
+        executorService.awaitTermination(1, TimeUnit.MINUTES);
+
+
+    }
+}


### PR DESCRIPTION
### **경기 예약**

- **시나리오**: 사용자가 동일한 경기를 동시에 예약하는 상황을 방지합니다.
    1. 사용자가 특정 경기를 예약하려고 하면, Redisson의 Rlock으로 잠금을 설정합니다.
    2. 예약 처리가 완료되면 Redis 잠금을 해제합니다.

### **쿠폰**

- **시나리오**: 한정된 수량의 쿠폰을 다수의 사용자가 동시에 요청하는 경우.
    1. 쿠폰이 `0` 이하가 되면 더 이상 발급되지 않도록 처리합니다.
    2. 쿠폰 발급 시, 쿠폰코드로 key값을 생성해 Redis에 저장하여 중복 사용을 방지합니다.